### PR TITLE
[feat] 범용 Tag 컴포넌트 구현

### DIFF
--- a/src/components/common/tag/Tag.stories.tsx
+++ b/src/components/common/tag/Tag.stories.tsx
@@ -1,0 +1,237 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Tag from "@/components/common/tag/Tag";
+
+const meta: Meta<typeof Tag> = {
+  title: "Common/Tag",
+  component: Tag,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    text: {
+      control: "text",
+      description: "태그에 표시될 텍스트",
+    },
+    variant: {
+      control: "select",
+      options: ["filled", "outlined", "interactive", "selected"],
+      description: "태그의 스타일 variant",
+    },
+    size: {
+      control: "select",
+      options: ["xs", "sm", "md", "lg", "xl"],
+      description: "태그의 크기",
+    },
+    selectable: {
+      control: "boolean",
+      description: "클릭 가능한 태그 여부",
+    },
+    selected: {
+      control: "boolean",
+      description: "선택된 상태 (selectable이 true일 때만 적용)",
+    },
+    disabled: {
+      control: "boolean",
+      description: "비활성화 상태",
+    },
+    onClick: {
+      action: "clicked",
+      description: "클릭 이벤트 핸들러",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 기본 정적 태그 (filled)
+export const Default: Story = {
+  args: {
+    text: "기본 태그",
+    variant: "filled",
+    size: "md",
+    selectable: false,
+  },
+};
+
+// 정적 태그 - Filled
+export const StaticFilled: Story = {
+  args: {
+    text: "자가 보유",
+    variant: "filled",
+    size: "md",
+    selectable: false,
+  },
+};
+
+// 정적 태그 - Outlined
+export const StaticOutlined: Story = {
+  args: {
+    text: "적극투자 선호",
+    variant: "outlined",
+    size: "md",
+    selectable: false,
+  },
+};
+
+// 선택 가능한 태그 (기본 상태)
+export const SelectableDefault: Story = {
+  args: {
+    text: "내 집 마련",
+    size: "md",
+    selectable: true,
+    selected: false,
+  },
+};
+
+// 선택 가능한 태그 (선택된 상태)
+export const SelectableSelected: Story = {
+  args: {
+    text: "선택된 태그",
+    size: "md",
+    selectable: true,
+    selected: true,
+  },
+};
+
+// 비활성화된 정적 태그
+export const StaticDisabled: Story = {
+  args: {
+    text: "비활성화 태그",
+    variant: "filled",
+    size: "md",
+    selectable: false,
+    disabled: true,
+  },
+};
+
+// 비활성화된 선택 가능한 태그
+export const SelectableDisabled: Story = {
+  args: {
+    text: "선택 불가",
+    size: "md",
+    selectable: true,
+    selected: false,
+    disabled: true,
+  },
+};
+
+// 모든 크기 테스트
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-3">
+      <Tag text="XS" size="xs" selectable={false} />
+      <Tag text="Small" size="sm" selectable={false} />
+      <Tag text="Medium" size="md" selectable={false} />
+      <Tag text="Large" size="lg" selectable={false} />
+      <Tag text="Extra Large" size="xl" selectable={false} />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "태그의 모든 크기를 비교해볼 수 있습니다.",
+      },
+    },
+  },
+};
+
+// 모든 variant 테스트용
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Tag text="Filled" variant="filled" selectable={false} />
+      <Tag text="Outlined" variant="outlined" selectable={false} />
+      <Tag text="Interactive" selectable={true} selected={false} />
+      <Tag text="Selected" selectable={true} selected={true} />
+      <Tag
+        text="Disabled"
+        variant="filled"
+        selectable={false}
+        disabled={true}
+      />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "모든 태그 variant를 한 번에 확인할 수 있습니다.",
+      },
+    },
+  },
+};
+
+// 실제 사용 시나리오 - 필터 태그들
+export const FilterScenario: Story = {
+  render: () => (
+    <div className="space-y-4 p-4">
+      <div>
+        <h3 className="text-sm font-medium text-gray-700 mb-2">투자 성향</h3>
+        <div className="flex flex-wrap gap-2">
+          <Tag
+            text="안전투자 선호"
+            selectable={true}
+            selected={true}
+            size="sm"
+          />
+          <Tag
+            text="적극투자 선호"
+            selectable={true}
+            selected={false}
+            size="sm"
+          />
+          <Tag
+            text="고수익 추구"
+            selectable={true}
+            selected={false}
+            size="sm"
+          />
+        </div>
+      </div>
+      <div>
+        <h3 className="text-sm font-medium text-gray-700 mb-2">보유 자산</h3>
+        <div className="flex flex-wrap gap-2">
+          <Tag text="자가 보유" selectable={true} selected={false} size="sm" />
+          <Tag text="전세" selectable={true} selected={true} size="sm" />
+          <Tag text="월세" selectable={true} selected={false} size="sm" />
+        </div>
+      </div>
+    </div>
+  ),
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        story: "실제 필터 기능에서 사용되는 태그들의 예시입니다.",
+      },
+    },
+  },
+};
+
+// 카테고리 라벨 시나리오
+export const CategoryScenario: Story = {
+  render: () => (
+    <div className="space-y-4 p-4">
+      <div>
+        <h3 className="text-sm font-medium text-gray-700 mb-2">
+          상품 카테고리
+        </h3>
+        <div className="flex flex-wrap gap-2">
+          <Tag text="NEW" variant="filled" size="xs" selectable={false} />
+          <Tag text="BEST" variant="outlined" size="sm" selectable={false} />
+          <Tag text="적금" variant="filled" size="md" selectable={false} />
+          <Tag text="예금" variant="outlined" size="md" selectable={false} />
+        </div>
+      </div>
+    </div>
+  ),
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        story: "상품 카테고리나 라벨용 태그들의 예시입니다.",
+      },
+    },
+  },
+};

--- a/src/components/common/tag/Tag.tsx
+++ b/src/components/common/tag/Tag.tsx
@@ -1,0 +1,10 @@
+import type { TagProps } from "@/components/common/tag/type/types";
+import StaticTag from "@/components/common/tag/type/StaticTag";
+import InteractiveTag from "@/components/common/tag/type/InteractiveTag";
+
+export default function Tag(props: TagProps) {
+  if (props.selectable) {
+    return <InteractiveTag {...props} />;
+  }
+  return <StaticTag {...props} />;
+}

--- a/src/components/common/tag/type/InteractiveTag.tsx
+++ b/src/components/common/tag/type/InteractiveTag.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { cn } from "@/utils/cn";
+import { tagVariants } from "@/components/common/tag/type/styles";
+import type { TagProps } from "@/components/common/tag/type/types";
+
+export default function InteractiveTag({
+  text,
+  selected,
+  size = "md",
+  disabled,
+  className,
+  onClick,
+  ...props
+}: Omit<TagProps, "selectable">) {
+  const variant = selected ? "selected" : "interactive";
+
+  return (
+    <div
+      role="button"
+      onClick={!disabled ? onClick : undefined}
+      className={cn(
+        tagVariants({ variant, size, disabled }),
+        "cursor-pointer",
+        className,
+      )}
+      {...props}
+    >
+      {text}
+    </div>
+  );
+}

--- a/src/components/common/tag/type/StaticTag.tsx
+++ b/src/components/common/tag/type/StaticTag.tsx
@@ -1,0 +1,21 @@
+import { cn } from "@/utils/cn";
+import { tagVariants } from "@/components/common/tag/type/styles";
+import type { TagProps } from "@/components/common/tag/type/types";
+
+export default function StaticTag({
+  text,
+  variant = "filled",
+  size = "md",
+  disabled,
+  className,
+  ...props
+}: TagProps) {
+  return (
+    <div
+      className={cn(tagVariants({ variant, size, disabled }), className)}
+      {...props}
+    >
+      {text}
+    </div>
+  );
+}

--- a/src/components/common/tag/type/styles.ts
+++ b/src/components/common/tag/type/styles.ts
@@ -1,0 +1,32 @@
+import { cva } from "class-variance-authority";
+
+export const tagVariants = cva(
+  "inline-flex items-center justify-center rounded-2xl font-semibold transition-colors duration-200",
+  {
+    variants: {
+      variant: {
+        filled: "bg-hanagreen-light text-hanagreen-normal",
+        outlined:
+          "bg-white text-hanagreen-normal border border-hanagreen-light border-[2px]",
+        interactive: "bg-hanagreen-light text-hanagreen-normal",
+        selected: "bg-hanagreen-normal text-hanagreen-light",
+      },
+      size: {
+        xs: "px-2 py-1 text-xs",
+        sm: "px-3 py-1.5 text-sm",
+        md: "px-4 py-2 text-sm",
+        lg: "px-5 py-2.5 text-base rounded-3xl",
+        xl: "px-6 py-3 text-lg rounded-3xl",
+      },
+      disabled: {
+        true: "opacity-50 cursor-not-allowed",
+        false: "",
+      },
+    },
+    defaultVariants: {
+      variant: "filled",
+      size: "md",
+      disabled: false,
+    },
+  },
+);

--- a/src/components/common/tag/type/types.ts
+++ b/src/components/common/tag/type/types.ts
@@ -1,0 +1,13 @@
+import type { HTMLAttributes } from "react";
+import type { VariantProps } from "class-variance-authority";
+import { tagVariants } from "@/components/common/tag/type/styles";
+
+export interface TagProps
+  extends HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof tagVariants> {
+  text: string;
+  selectable?: boolean;
+  selected?: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+}


### PR DESCRIPTION
## #️⃣ Issue Number
closed #7 

## 📝 요약(Summary)
재사용 가능하고 확장 가능한 Tag 컴포넌트를 구현했습니다.
정적 태그와 인터랙티브 태그 두 가지 형태를 지원하며, 다양한 크기와 스타일을 제공합니다.


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가

## 📸스크린샷 (선택)
<img width="522" alt="image" src="https://github.com/user-attachments/assets/a9331ab6-d78d-46df-9df4-d02b2a245634" />
<img width="521" alt="image" src="https://github.com/user-attachments/assets/3c0a35ac-a027-40c7-8113-80582e66975d" />
<img width="341" alt="image" src="https://github.com/user-attachments/assets/5cfb6ad1-0f36-4828-a5dc-9531e99fa357" />


## 💬 공유사항 to 리뷰어
### + Tag 컴포넌트 사용법 가이드

+ 정적 태그
```
import Tag from "@/components/common/tag/Tag";

// 정적 태그 (기본)
<Tag text="자가 보유" />
// 크기 지정
<Tag text="작은 태그" size="sm" />
// 스타일 variant 지정
<Tag text="아웃라인 태그" variant="outlined" />
```

+ 동적 태그
```
// 선택 가능한 태그
<Tag 
  text="내 집 마련" 
  selectable={true}
  selected={false}
  onClick={() => console.log('clicked')}
/>

// 선택된 상태
<Tag 
  text="선택된 태그" 
  selectable={true}
  selected={true}
/>

// 비활성화된 태그
<Tag 
  text="비활성화" 
  selectable={true}
  disabled={true}
/>
```

### 🎨 Props API
#### `TagProps` Interface

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `text` | `string` | **required** | 태그에 표시될 텍스트 |
| `variant` | `"filled" \| "outlined" \| "interactive" \| "selected"` | `"filled"` | 태그의 시각적 스타일 |
| `size` | `"xs" \| "sm" \| "md" \| "lg" \| "xl"` | `"md"` | 태그의 크기 |
| `selectable` | `boolean` | `false` | 클릭 가능한 태그 여부 |
| `selected` | `boolean` | `false` | 선택된 상태 (selectable일 때만) |
| `disabled` | `boolean` | `false` | 비활성화 상태 |
| `onClick` | `() => void` | `undefined` | 클릭 이벤트 핸들러 |
| `className` | `string` | `undefined` | 추가 CSS 클래스 |

### 🎭 Variants
#### Size Options
- **`xs`**: `px-2 py-1 text-xs rounded-lg` - 가장 작은 크기
- **`sm`**: `px-3 py-1.5 text-sm rounded-xl` - 작은 크기  
- **`md`**: `px-4 py-2 text-sm rounded-2xl` - 기본 크기
- **`lg`**: `px-5 py-2.5 text-base rounded-2xl` - 큰 크기
- **`xl`**: `px-6 py-3 text-lg rounded-3xl` - 가장 큰 크기

### Style Variants
- **`filled`**: `bg-hanagreen-light text-hanagreen-normal` - 채워진 스타일
- **`outlined`**: `bg-white text-hanagreen-normal border border-hanagreen-light` - 테두리 스타일
- **`interactive`**: `bg-hanagreen-light text-hanagreen-normal` - 인터랙티브 기본 상태
- **`selected`**: `bg-hanagreen-normal text-hanagreen-light` - 선택된 상태
