### PR TITLE
[design] 바텀바 너비, 헤더 패딩 수정

### DIFF
--- a/src/app/(navbar)/layout.tsx
+++ b/src/app/(navbar)/layout.tsx
@@ -6,7 +6,7 @@ export default function BottomNavLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="mx-auto max-w-3xl w-full h-screen">
+    <div className="w-full h-screen">
       {children}
       <BottomNav />
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,9 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@layer utilities {
+  .frame-mobile {
+    @apply w-full max-w-[393px] mx-auto;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
   return (
     <html lang="ko" className={`${pretendard.variable}`}>
       <body className={`${pretendard.className} flex justify-center`}>
-        <div className="flex flex-col w-[393px] h-screen px-[20px] bg-background border-black border">
+        <div className="flex flex-col frame-mobile h-screen px-[20px] bg-background border-black border">
           {children}
         </div>
       </body>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -16,7 +16,7 @@ const BackButton = () => {
 
   return (
     <button
-      className="p-2 z-10 cursor-pointer"
+      className="py-2 pr-2 z-10 cursor-pointer"
       type="button"
       onClick={() => router.back()}
     >
@@ -38,12 +38,12 @@ export default function Header({
       <h1
         className={clsx(
           "text-2xl font-normal text-text-primary absolute left-0 right-0",
-          centerTitle ? "text-center" : "text-left px-5",
+          centerTitle ? "text-center" : "text-left",
         )}
       >
         {title}
       </h1>
-      <div className="absolute right-0 pr-5">{children}</div>
+      <div className="absolute right-0">{children}</div>
     </header>
   );
 }

--- a/src/components/navbar/BottomNav.tsx
+++ b/src/components/navbar/BottomNav.tsx
@@ -57,7 +57,10 @@ const navItems = [
 
 export default function BottomNav() {
   return (
-    <nav className="flex fixed left-0 right-0 bottom-0 py-2 border-t border-hanasilver bg-white justify-evenly items-center z-50 w-full">
+    <nav
+      className="fixed bottom-0 left-1/2 -translate-x-1/2 frame-mobile z-50 
+             flex items-center justify-evenly py-2 border-t border-hanasilver bg-white"
+    >
       {navItems.map((item) => {
         return (
           <BottomNavButton

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,9 @@ module.exports = {
       boxShadow: {
         "card-shadow": "0px -1px 6px 0px rgba(0, 0, 0, 0.25)",
       },
+      maxWidth: {
+        mobile: "393px",
+      },
       colors: {
         hanagold: "#ad9a5f",
         hanasilver: "#b5b5b5",


### PR DESCRIPTION
<!--- PR 제목을 "[카테고리] 구현한 거 설명" 으로 작성했나요? -->
<!--- ex)[feat] 로그인 API 연동 -->

## #️⃣ Issue Number
#22 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
바텀바 너비를 화면 크기에 맞게 수정했습니다.
바뀐 화면 너비에 맞게 헤더의 패딩을 수정했습니다.
frame-mobile이라는 전체 프레임 너비를 제한하는 css 클래스를 만들었습니다.

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
| 제목     | 설명                               | 이미지 |
|----------|------------------------------------|--------|
| 바텀바   | 화면 너비에 맞게 조절되는 바텀바입니다 | ![image](https://github.com/user-attachments/assets/197bda92-2df0-434e-9640-76dcaec0a158) |

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
