### PR TITLE
[feat] Input, InputWithLabel 컴포넌트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3473,6 +3473,111 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.3.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.3.tgz",
+      "integrity": "sha512-XHdzH/yBc55lu78k/XwtuFR/ZXUTcflpRXcsu0nKmF45U96jt1tsOZhVrn5YH+paw66zOANpOnFQ9i6/j+UYvw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.3.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.3.tgz",
+      "integrity": "sha512-VZ3sYL2LXB8znNGcjhocikEkag/8xiLgnvQts41tq6i+wql63SMS1Q6N8RVXHw5pEUjiof+II3HkDd7GFcgkzw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.3.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.3.tgz",
+      "integrity": "sha512-h6Y1fLU4RWAp1HPNJWDYBQ+e3G7sLckyBXhmH9ajn8l/RSMnhbuPBV/fXmy3muMcVwoJdHL+UtzRzs0nXOf9SA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.3.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.3.tgz",
+      "integrity": "sha512-jJ8HRiF3N8Zw6hGlytCj5BiHyG/K+fnTKVDEKvUCyiQ/0r5tgwO7OgaRiOjjRoIx2vwLR+Rz8hQoPrnmFbJdfw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.3.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.3.tgz",
+      "integrity": "sha512-HrUcTr4N+RgiiGn3jjeT6Oo208UT/7BuTr7K0mdKRBtTbT4v9zJqCDKO97DUqqoBK1qyzP1RwvrWTvU6EPh/Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.3.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.3.tgz",
+      "integrity": "sha512-SxorONgi6K7ZUysMtRF3mIeHC5aA3IQLmKFQzU0OuhuUYwpOBc1ypaLJLP5Bf3M9k53KUUUj4vTPwzGvl/NwlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.3.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.3.tgz",
+      "integrity": "sha512-4QZG6F8enl9/S2+yIiOiju0iCTFd93d8VC1q9LZS4p/Xuk81W2QDjCFeoogmrWWkAD59z8ZxepBQap2dKS5ruw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -16002,111 +16107,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.3.tgz",
-      "integrity": "sha512-XHdzH/yBc55lu78k/XwtuFR/ZXUTcflpRXcsu0nKmF45U96jt1tsOZhVrn5YH+paw66zOANpOnFQ9i6/j+UYvw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.3.tgz",
-      "integrity": "sha512-VZ3sYL2LXB8znNGcjhocikEkag/8xiLgnvQts41tq6i+wql63SMS1Q6N8RVXHw5pEUjiof+II3HkDd7GFcgkzw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.3.tgz",
-      "integrity": "sha512-h6Y1fLU4RWAp1HPNJWDYBQ+e3G7sLckyBXhmH9ajn8l/RSMnhbuPBV/fXmy3muMcVwoJdHL+UtzRzs0nXOf9SA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.3.tgz",
-      "integrity": "sha512-jJ8HRiF3N8Zw6hGlytCj5BiHyG/K+fnTKVDEKvUCyiQ/0r5tgwO7OgaRiOjjRoIx2vwLR+Rz8hQoPrnmFbJdfw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.3.tgz",
-      "integrity": "sha512-HrUcTr4N+RgiiGn3jjeT6Oo208UT/7BuTr7K0mdKRBtTbT4v9zJqCDKO97DUqqoBK1qyzP1RwvrWTvU6EPh/Cw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.3.tgz",
-      "integrity": "sha512-SxorONgi6K7ZUysMtRF3mIeHC5aA3IQLmKFQzU0OuhuUYwpOBc1ypaLJLP5Bf3M9k53KUUUj4vTPwzGvl/NwlQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.3.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.3.tgz",
-      "integrity": "sha512-4QZG6F8enl9/S2+yIiOiju0iCTFd93d8VC1q9LZS4p/Xuk81W2QDjCFeoogmrWWkAD59z8ZxepBQap2dKS5ruw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/src/components/common/input/Input.stories.tsx
+++ b/src/components/common/input/Input.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Input from "@/components/common/input/Input";
+
+const meta: Meta<typeof Input> = {
+  title: "Common/Input",
+  component: Input,
+  tags: ["autodocs"],
+  argTypes: {
+    placeholder: { control: "text" },
+    fullWidth: { control: "boolean" },
+    variant: {
+      control: "radio",
+      options: ["outlined", "standard"],
+    },
+    type: {
+      control: "select",
+      options: ["text", "number", "email", "password"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {
+  args: {
+    placeholder: "메세지를 입력하세요.",
+    fullWidth: true,
+    variant: "outlined",
+  },
+};
+
+export const WithCustomWidth: Story = {
+  args: {
+    placeholder: "1천만원",
+    fullWidth: false,
+    variant: "outlined",
+    className: "w-60",
+    inputClassName: "text-lg font-bold",
+  },
+};
+
+export const PasswordField: Story = {
+  args: {
+    placeholder: "비밀번호",
+    type: "password",
+    fullWidth: false,
+    className: "w-72",
+  },
+};

--- a/src/components/common/input/Input.stories.tsx
+++ b/src/components/common/input/Input.stories.tsx
@@ -48,3 +48,23 @@ export const PasswordField: Story = {
     className: "w-72",
   },
 };
+
+export const WithUnitSuffix: Story = {
+  args: {
+    placeholder: "몸무게",
+    unit: "kg",
+    unitPosition: "end",
+    fullWidth: false,
+    className: "w-56",
+  },
+};
+
+export const WithUnitPrefix: Story = {
+  args: {
+    placeholder: "금액",
+    unit: "₩",
+    unitPosition: "start",
+    fullWidth: false,
+    className: "w-56",
+  },
+};

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TextField, TextFieldProps } from "@mui/material";
+import { TextField, TextFieldProps, InputAdornment } from "@mui/material";
 import { cn } from "@/utils/cn";
 import { forwardRef } from "react";
 import { colors } from "@/components/common/input/styles";
@@ -10,6 +10,8 @@ export interface CustomInputProps extends Omit<TextFieldProps, "variant"> {
   className?: string;
   inputClassName?: string;
   variant?: "outlined" | "standard";
+  unit?: string;
+  unitPosition?: "start" | "end";
 }
 
 const Input = forwardRef<HTMLInputElement, CustomInputProps>(
@@ -19,10 +21,19 @@ const Input = forwardRef<HTMLInputElement, CustomInputProps>(
       inputClassName,
       fullWidth = false,
       variant = "outlined",
+      unit,
+      unitPosition = "end",
       ...props
     },
     ref,
   ) => {
+    const adornment =
+      unit && unit.length > 0 ? (
+        <InputAdornment position={unitPosition}>
+          <span className="text-placeholder text-sm">{unit}</span>
+        </InputAdornment>
+      ) : null;
+
     return (
       <TextField
         {...props}
@@ -32,6 +43,12 @@ const Input = forwardRef<HTMLInputElement, CustomInputProps>(
         className={cn("rounded-lg h-9", className)}
         InputProps={{
           ...props.InputProps,
+          endAdornment:
+            unitPosition === "end" ? adornment : props.InputProps?.endAdornment,
+          startAdornment:
+            unitPosition === "start"
+              ? adornment
+              : props.InputProps?.startAdornment,
           classes: {
             ...props.InputProps?.classes,
           },

--- a/src/components/common/input/Input.tsx
+++ b/src/components/common/input/Input.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { TextField, TextFieldProps } from "@mui/material";
+import { cn } from "@/utils/cn";
+import { forwardRef } from "react";
+import { colors } from "@/components/common/input/styles";
+
+export interface CustomInputProps extends Omit<TextFieldProps, "variant"> {
+  fullWidth?: boolean;
+  className?: string;
+  inputClassName?: string;
+  variant?: "outlined" | "standard";
+}
+
+const Input = forwardRef<HTMLInputElement, CustomInputProps>(
+  (
+    {
+      className,
+      inputClassName,
+      fullWidth = false,
+      variant = "outlined",
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <TextField
+        {...props}
+        variant={variant}
+        fullWidth={fullWidth}
+        inputRef={ref}
+        className={cn("rounded-lg h-9", className)}
+        InputProps={{
+          ...props.InputProps,
+          classes: {
+            ...props.InputProps?.classes,
+          },
+          className: cn("bg-white", props.InputProps?.className),
+        }}
+        inputProps={{
+          ...props.inputProps,
+          className: cn(
+            "px-4 py-2 text-primary-text placeholder:text-placeholder",
+            inputClassName,
+            props.inputProps?.className,
+          ),
+        }}
+        sx={{
+          "& .MuiOutlinedInput-root": {
+            borderRadius: "0.5rem",
+            height: "36px",
+            "& fieldset": {
+              borderColor: colors.hanasilver,
+              borderWidth: 1,
+            },
+            "&:hover fieldset": {
+              borderColor: colors.hanasilver,
+            },
+            "&.Mui-focused fieldset": {
+              borderColor: colors.hanagreen.normal,
+            },
+          },
+        }}
+      />
+    );
+  },
+);
+
+Input.displayName = "Input";
+export default Input;

--- a/src/components/common/input/InputWithLabel.stories.tsx
+++ b/src/components/common/input/InputWithLabel.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import InputWithLabel from "@/components/common/input/InputWithLabel";
+import { useState } from "react";
+
+const meta: Meta<typeof InputWithLabel> = {
+  title: "Common/InputWithLabel",
+  component: InputWithLabel,
+  tags: ["autodocs"],
+  argTypes: {
+    label: { control: "text" },
+    placeholder: { control: "text" },
+    required: { control: "boolean" },
+    errorMessage: { control: "text" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof InputWithLabel>;
+
+export const Default: Story = {
+  args: {
+    label: "닉네임",
+    placeholder: "닉네임을 입력해주세요",
+    required: false,
+  },
+};
+
+export const Required: Story = {
+  args: {
+    label: "한 줄 소개",
+    placeholder: "성수에 살고 분당에서 일해요",
+    required: true,
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    label: "한 줄 소개",
+    placeholder: "성수에 살고 분당에서 일해요",
+    required: true,
+    errorMessage: "내용을 입력해주세요",
+  },
+};
+
+export const Controlled: Story = {
+  render: () => {
+    const [value, setValue] = useState("");
+    return (
+      <InputWithLabel
+        label="한 줄 소개"
+        placeholder="성수에 살고 분당에서 일해요"
+        required
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        errorMessage={value.length === 0 ? "필수 입력입니다." : ""}
+      />
+    );
+  },
+};

--- a/src/components/common/input/InputWithLabel.tsx
+++ b/src/components/common/input/InputWithLabel.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { forwardRef } from "react";
+import { TextField, TextFieldProps } from "@mui/material";
+import { cn } from "@/utils/cn";
+import { colors } from "@/components/common/input/styles";
+
+export interface InputWithLabelProps extends Omit<TextFieldProps, "variant"> {
+  label: string;
+  required?: boolean;
+  errorMessage?: string;
+  fullWidth?: boolean;
+  className?: string;
+  inputClassName?: string;
+}
+
+const InputWithLabel = forwardRef<HTMLInputElement, InputWithLabelProps>(
+  (
+    {
+      label,
+      required = false,
+      errorMessage,
+      className,
+      inputClassName,
+      fullWidth = true,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <TextField
+        {...props}
+        inputRef={ref}
+        variant="standard"
+        fullWidth={fullWidth}
+        label={
+          <span>
+            {label}
+            {required && <span className="text-hanared-normal ml-1">*</span>}
+          </span>
+        }
+        error={!!errorMessage}
+        helperText={errorMessage}
+        className={cn("text-base", className)}
+        InputProps={{
+          ...props.InputProps,
+          disableUnderline: false,
+          className: cn("text-hanasilver", props.InputProps?.className),
+        }}
+        inputProps={{
+          ...props.inputProps,
+          className: cn(
+            "placeholder:text-placeholder px-0 py-2",
+            inputClassName,
+            props.inputProps?.className,
+          ),
+        }}
+        sx={{
+          "& .MuiInputBase-root": {
+            fontSize: "1rem",
+          },
+          "& .MuiInput-underline:before": {
+            borderBottomColor: colors.hanasilver,
+          },
+          "& .MuiInput-underline:hover:before": {
+            borderBottomColor: colors.hanasilver,
+          },
+          "& .MuiInput-underline:after": {
+            borderBottomColor: errorMessage
+              ? colors.hanared.normal
+              : colors.hanagreen.normal,
+          },
+        }}
+      />
+    );
+  },
+);
+
+InputWithLabel.displayName = "InputWithLabel";
+export default InputWithLabel;

--- a/src/components/common/input/styles.ts
+++ b/src/components/common/input/styles.ts
@@ -1,0 +1,6 @@
+export const colors = {
+  hanagreen: {
+    normal: "#008485",
+  },
+  hanasilver: "#b5b5b5",
+};

--- a/src/components/common/input/styles.ts
+++ b/src/components/common/input/styles.ts
@@ -3,4 +3,7 @@ export const colors = {
     normal: "#008485",
   },
   hanasilver: "#b5b5b5",
+  hanared: {
+    normal: "#e90061",
+  },
 };


### PR DESCRIPTION
## #️⃣ Issue Number

closed #15 

## 📝 요약(Summary)

MUI 기반의 Input 컴포넌트와 InputWithLabel 컴포넌트를 공통 컴포넌트로 도입하였습니다.
TailwindCSS를 활용한 디자인 커스터마이징 및 유연한 스타일 적용이 가능합니다.
Input은 기본 input 필드용이며, InputWithLabel은 라벨이 포함된 입력 필드를 제공합니다.
prefix / suffix 단위를 지원합니다. (unit, unitPosition props)
````
사용 컴포넌트
@mui/material/TextField
class-variance-authority, tailwind-merge 기반 cn() 유틸리티
InputAdornment (MUI) 사용하여 단위 표기 지원
````
## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가

## 📸스크린샷 (선택)
<img width="359" alt="스크린샷 2025-06-13 오전 10 34 30" src="https://github.com/user-attachments/assets/a6b7b337-1e4a-4c18-a624-fa5017a63236" />
<img width="317" alt="스크린샷 2025-06-13 오전 10 34 46" src="https://github.com/user-attachments/assets/c11f0991-01c7-4d55-afc0-72c4aeb32a74" />
<img width="250" alt="스크린샷 2025-06-13 오전 10 34 55" src="https://github.com/user-attachments/assets/d98be362-bd95-41fe-afd0-efe0e9ad6807" />
<img width="250" alt="스크린샷 2025-06-13 오전 10 35 02" src="https://github.com/user-attachments/assets/eb17c02a-09b1-4ab3-b33b-092d0b816500" />
<img width="355" alt="스크린샷 2025-06-13 오전 10 35 19" src="https://github.com/user-attachments/assets/0affea14-977e-4649-872b-e5794e4e378e" />
<img width="379" alt="스크린샷 2025-06-13 오전 10 35 27" src="https://github.com/user-attachments/assets/7410bf41-4b71-4c2e-b5c4-314908971348" />

더 자세한 UI는 storybook을 참고해 주세요:)

## 💬 공유사항 to 리뷰어
### 1. Input 컴포넌트 사용법 가이드
```
기본
<Input placeholder="메시지를 입력하세요." />
```
```
커스텀 스타일 적용
<Input
  placeholder="1천만원"
  className="w-60"
  inputClassName="text-lg font-bold"
/>
```
```
단위 붙이기
<Input
  placeholder="몸무게"
  unit="kg"
  unitPosition="end"
/>

<Input
  placeholder="금액"
  unit="₩"
  unitPosition="start"
/>
```
```
비밀번호 필드
<Input
  type="password"
  placeholder="비밀번호 입력"
/>
```
#### 📌 Input Props 설명
<html><head></head><body>

Prop | Type | 설명 | 예시
-- | -- | -- | --
placeholder | string | 인풋 필드에 표시될 플레이스홀더 텍스트입니다. | placeholder="이름을 입력하세요"
variant | "outlined" / "standard" | MUI TextField의 variant를 설정합니다. 기본은 "outlined"입니다. | variant="outlined"
fullWidth | boolean | 가로폭을 100%로 지정할지 여부입니다. | fullWidth={true}
className | string | TextField 외부 wrapper 스타일 커스터마이징을 위한 클래스명입니다. | className="w-60"
inputClassName | string | 인풋 내부 스타일을 위한 클래스명입니다. | inputClassName="text-lg"
unit | string | 단위 표시용 접미어/접두어 문자열입니다. | unit="kg"
unitPosition | "start" / "end" | 단위 위치를 지정합니다. "start"는 앞에, "end"는 뒤에 붙습니다. | unitPosition="end"
type | "text" \| "number" \| 등 | 인풋의 HTML 타입을 지정합니다. | type="password"
...props | TextFieldProps (MUI 확장) | MUI의 <TextField />에서 제공하는 나머지 모든 속성을 지원합니다. | -

</body></html>


### 2. InputWithLabel 사용법
```
기본
<InputWithLabel label="닉네임" placeholder="닉네임을 입력해주세요" />
```
```
필수 입력 처리
<InputWithLabel
  label="한 줄 소개"
  required
  placeholder="성수에 살고 분당에서 일해요"
/>
```
* 표시는 required={true} 일 때 자동으로 표시됩니다.
```
에러 메시지 적용
<InputWithLabel
  label="이메일"
  required
  placeholder="이메일을 입력해주세요"
  errorMessage="유효한 이메일을 입력해주세요"
/>
```
에러 발생 시 TextField는 error 상태로 전환되며, helperText에 오류 메시지가 표시됩니다. validate에 활용해 주세요!

#### 📌 InputWithLabel Props 설명
<html><head></head><body>

Prop | Type | 설명 | 예시
-- | -- | -- | --
label | string | 인풋 위에 표시될 라벨 텍스트입니다. | label="닉네임"
required | boolean | 필수 항목일 경우 * 표시가 자동으로 붙습니다. | required={true}
errorMessage | string | 유효성 검사 실패 시 에러 메시지를 보여줍니다. | errorMessage="입력이 필요합니다"
className | string | 인풋 외부 wrapper 스타일 클래스입니다. | className="mt-4"
inputClassName | string | 인풋 내부 input 스타일 클래스입니다. | inputClassName="font-bold"
fullWidth | boolean | 인풋의 너비를 100%로 지정할지 여부입니다. | fullWidth={true}
...props | TextFieldProps | MUI의 <TextField /> 컴포넌트의 기본 props 확장입니다. | -

</body></html>