### PR TITLE
[feat] 프로필 등록 페이지 UI 구현

### DIFF
--- a/src/app/(onboarding)/profile-setup/page.tsx
+++ b/src/app/(onboarding)/profile-setup/page.tsx
@@ -1,3 +1,149 @@
+"use client";
+
+import { useState } from "react";
+import Header from "@/components/common/Header";
+import ImageUploader from "@/components/profile/imageUploader/ImageUploader";
+import InfoCard from "@/components/common/InfoCard";
+import InputWithLabel from "@/components/common/input/InputWithLabel";
+import Input from "@/components/common/input/Input";
+import Tag from "@/components/common/tag/Tag";
+import AssetToggleRow from "@/components/profile/AssetToggleRow";
+import Button from "@/components/common/button/Button";
+
+const GOAL_TAGS = ["내 집 마련", "목돈 마련", "노후 자금", "결혼 자금"];
+
 export default function ProfileSetUpPage() {
-  return <div className="w-full h-full">프로필</div>;
+  const [selectedGoal, setSelectedGoal] = useState<string | null>(null);
+  const [introduction, setIntroduction] = useState("");
+  const [job, setJob] = useState("");
+  const [goalAmount, setGoalAmount] = useState("");
+  const [goalPeriod, setGoalPeriod] = useState("");
+
+  const isFormComplete =
+    introduction.trim() !== "" &&
+    job.trim() !== "" &&
+    selectedGoal !== null &&
+    goalAmount.trim() !== "" &&
+    goalPeriod.trim() !== "";
+
+  return (
+    <div className="frame-container w-full min-h-screen bg-hanagreen-normal">
+      <Header title="프로필" />
+
+      <div className="relative mt-24 px-5">
+        {/* 프로필 이미지 업로더 */}
+        <div className="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2 z-10">
+          <div className="w-28 h-28 rounded-full bg-background flex items-center justify-center">
+            <ImageUploader onChange={() => {}} />
+          </div>
+        </div>
+
+        <div className="bg-background w-full min-h-[calc(100vh-64px)] pt-24 pb-10 px-4 shadow-md rounded-t-3xl">
+          <div className="flex flex-col space-y-[1.875rem]">
+            <div className="text-3xl font-semibold text-text-primary">
+              승희님, 안녕하세요
+            </div>
+
+            <InfoCard
+              content={
+                <>
+                  지금부터 <span className="text-hanagreen-normal">별돌이</span>
+                  와 함께 매력적인 프로필을 만들어보세요!
+                </>
+              }
+              imageType={"attentionStarBoy"}
+            />
+
+            <InputWithLabel
+              label="한 줄 소개"
+              required
+              placeholder="성수에 살고 분당에서 일해요"
+              value={introduction}
+              onChange={(e) => setIntroduction(e.target.value)}
+            />
+
+            <InputWithLabel
+              label="직업"
+              required
+              placeholder="학생"
+              value={job}
+              onChange={(e) => setJob(e.target.value)}
+            />
+
+            <div className="space-y-2">
+              <p className="text-sm font-normal text-text-primary">
+                목표 설정 <span className="text-hanared-normal">*</span>
+              </p>
+              <div className="flex flex-wrap gap-x-3 gap-y-2">
+                {GOAL_TAGS.map((goal) => (
+                  <Tag
+                    key={goal}
+                    text={goal}
+                    selectable
+                    selected={selectedGoal === goal}
+                    onClick={() => setSelectedGoal(goal)}
+                  />
+                ))}
+              </div>
+            </div>
+
+            {selectedGoal && (
+              <div className="space-y-4">
+                <div className="space-y-1">
+                  <p className="text-sm font-normal text-text-primary">
+                    목표 금액 <span className="text-hanared-normal">*</span>
+                  </p>
+                  <Input
+                    required
+                    placeholder="예: 1억"
+                    className="w-full"
+                    value={goalAmount}
+                    onChange={(e) => setGoalAmount(e.target.value)}
+                  />
+                </div>
+
+                <div className="space-y-1">
+                  <p className="text-sm font-normal text-text-primary">
+                    목표 기간 <span className="text-hanared-normal">*</span>
+                  </p>
+                  <Input
+                    required
+                    placeholder="목표 기간을 선택해 주세요"
+                    className="w-full"
+                    value={goalPeriod}
+                    onChange={(e) => setGoalPeriod(e.target.value)}
+                  />
+                </div>
+              </div>
+            )}
+
+            <div className="space-y-3">
+              <p className="text-sm font-normal text-text-primary">
+                실물 자산 보유 현황
+              </p>
+
+              <div>
+                <p className="text-sm text-text-primary mb-2">• 자차</p>
+                <AssetToggleRow unit="천만원" />
+              </div>
+
+              <div>
+                <p className="text-sm text-text-primary mb-2">• 부동산</p>
+                <AssetToggleRow unit="억원" />
+              </div>
+            </div>
+
+            <Button
+              intent={isFormComplete ? "red" : "default"}
+              size="full"
+              label="완료"
+              onClick={() => {
+                if (!isFormComplete) return;
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,6 +27,6 @@ body {
 
 @layer utilities {
   .frame-container {
-    @apply w-full max-w-[1024px] mx-auto px-5;
+    @apply w-full max-w-[1024px] mx-auto;
   }
 }

--- a/src/components/common/tag/Tag.tsx
+++ b/src/components/common/tag/Tag.tsx
@@ -4,7 +4,11 @@ import InteractiveTag from "@/components/common/tag/type/InteractiveTag";
 
 export default function Tag(props: TagProps) {
   if (props.selectable) {
-    return <InteractiveTag {...props} />;
+    const cleanedProps = { ...props };
+    delete cleanedProps.selectable;
+
+    return <InteractiveTag {...cleanedProps} />;
   }
+
   return <StaticTag {...props} />;
 }

--- a/src/components/common/tag/type/InteractiveTag.tsx
+++ b/src/components/common/tag/type/InteractiveTag.tsx
@@ -11,7 +11,7 @@ export default function InteractiveTag({
   disabled,
   className,
   onClick,
-  ...props
+  ...rest
 }: Omit<TagProps, "selectable">) {
   const variant = selected ? "selected" : "interactive";
 
@@ -24,7 +24,7 @@ export default function InteractiveTag({
         "cursor-pointer",
         className,
       )}
-      {...props}
+      {...rest}
     >
       {text}
     </div>

--- a/src/components/profile/AssetToggleRow.tsx
+++ b/src/components/profile/AssetToggleRow.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+import Input from "@/components/common/input/Input";
+import Tag from "@/components/common/tag/Tag";
+
+interface AssetToggleRowProps {
+  unit: string;
+}
+
+export default function AssetToggleRow({ unit }: AssetToggleRowProps) {
+  const [isOwned, setIsOwned] = useState<boolean>(false);
+  const [marketPrice, setMarketPrice] = useState<string>("");
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 whitespace-nowrap">
+        <Tag
+          text="보유"
+          selectable
+          selected={isOwned}
+          onClick={() => setIsOwned(true)}
+        />
+        <Tag
+          text="미보유"
+          selectable
+          selected={!isOwned}
+          onClick={() => setIsOwned(false)}
+        />
+      </div>
+
+      {isOwned && (
+        <div className="flex-1">
+          <Input
+            placeholder="시세 입력"
+            unit={unit}
+            unitPosition="end"
+            value={marketPrice}
+            onChange={(e) => setMarketPrice(e.target.value)}
+            className="w-full"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/profile/imageUploader/ImageUploader.tsx
+++ b/src/components/profile/imageUploader/ImageUploader.tsx
@@ -45,7 +45,7 @@ export default function ImageUploader({
     <div className="flex flex-col items-center">
       <div
         onClick={handleClick}
-        className="relative w-40 h-40 rounded-full bg-gray-100 border border-hanasilver flex items-center justify-center cursor-pointer overflow-hidden"
+        className="relative w-24 h-24 rounded-full bg-background border border-hanasilver flex items-center justify-center cursor-pointer overflow-hidden"
       >
         {preview ? (
           <Image


### PR DESCRIPTION
## #️⃣ Issue Number
closed #27 

## 📝 요약(Summary)
프로필 등록 화면 전체 UI 구성
+ 사용자 이름 인사말 및 소개 카드 (Header, InfoCard 포함)
+ 프로필 이미지 업로더 (ImageUploader) 중앙 고정 배치
+ 입력 필드: 한 줄 소개, 직업
+ 목표 설정 태그 선택 UI (Tag 컴포넌트)
+ 목표 선택 시, 목표 금액 및 목표 기간 입력 필드 조건부 표시
+ 실물 자산 보유 현황 입력 영역 (자차, 부동산)
+ 보유/미보유 선택 버튼 (Tag 재사용)
+ 보유 선택 시 시세 입력 가능 (Input + 단위 표시)

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가

##  📸스크린샷 (선택)
<img width="445" alt="스크린샷 2025-06-16 오전 2 08 16" src="https://github.com/user-attachments/assets/bca8b73f-a42b-493c-8db1-bec3f408876e" />

<img width="450" alt="스크린샷 2025-06-16 오전 2 08 35" src="https://github.com/user-attachments/assets/dc69a31a-f767-4137-9f53-b1e09b9f6d94" />


## 💬 공유사항 to 리뷰어
추후 목표 기간 DatePicker로 교체할 예정입니다.
API 연동하면서 validation 로직 분리 등 리팩토링 진행 하겠습니다!
