### PR TITLE
[feat] 매칭 좋아요 기능 API 구현

### DIFF
--- a/src/app/api/likes/accept/route.ts
+++ b/src/app/api/likes/accept/route.ts
@@ -1,0 +1,59 @@
+/**
+ * @swagger
+ * /api/likes/accept:
+ *   patch:
+ *     summary: 받은 좋아요 수락
+ *     description: |
+ *       로그인한 사용자가 자신에게 온 좋아요 요청을 수락합니다.
+ *       matchId는 /api/likes/received에서 받아온 매칭 ID 사용를 사용합니다.
+ *     tags: [MatchLikes]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - matchId
+ *             properties:
+ *               matchId:
+ *                 type: integer
+ *                 description: 수락할 매칭의 ID
+ *     responses:
+ *       200:
+ *         description: 수락 처리 성공
+ *       403:
+ *         description: 수락 권한 없음
+ */
+
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getAuthUser } from "@/lib/auth";
+
+export async function PATCH(req: Request) {
+  const { matchId } = await req.json();
+  const user = await getAuthUser();
+  if (!user) {
+    return NextResponse.json(
+      { message: "인증되지 않은 사용자입니다." },
+      { status: 401 },
+    );
+  }
+  const userId = user.userId;
+
+  const match = await prisma.userMatchLog.findUnique({ where: { matchId } });
+
+  if (!match || match.receiveId !== userId) {
+    return NextResponse.json(
+      { message: "처리할 수 없는 요청입니다." },
+      { status: 403 },
+    );
+  }
+
+  await prisma.userMatchLog.update({
+    where: { matchId },
+    data: { matchStatus: "ACCEPTED" },
+  });
+
+  return NextResponse.json({ message: "수락 처리되었습니다." });
+}

--- a/src/app/api/likes/received/route.ts
+++ b/src/app/api/likes/received/route.ts
@@ -1,0 +1,67 @@
+/**
+ * @swagger
+ * /api/likes/received:
+ *   get:
+ *     summary: 내가 받은 좋아요 목록 조회
+ *     description: 로그인한 사용자가 현재까지 받은 좋아요(PENDING 상태)의 목록을 조회합니다.
+ *     tags: [MatchLikes]
+ *     responses:
+ *       200:
+ *         description: 받은 좋아요 목록 반환
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   matchId:
+ *                     type: integer
+ *                   matchStatus:
+ *                     type: string
+ *                   sent:
+ *                     type: object
+ *                     properties:
+ *                       userId:
+ *                         type: integer
+ *                       nickname:
+ *                         type: string
+ *                       profileImage:
+ *                         type: string
+ */
+
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getAuthUser } from "@/lib/auth";
+
+export async function GET() {
+  const user = await getAuthUser();
+  if (!user) {
+    return NextResponse.json(
+      { message: "인증되지 않은 사용자입니다." },
+      { status: 401 },
+    );
+  }
+  const userId = user.userId;
+
+  const receivedLikes = await prisma.userMatchLog.findMany({
+    where: {
+      receiveId: userId,
+      matchStatus: "PENDING",
+    },
+    include: {
+      sent: {
+        select: {
+          userId: true,
+          nickname: true,
+          profileImage: true,
+        },
+      },
+    },
+    orderBy: {
+      matchId: "desc",
+    },
+  });
+
+  return NextResponse.json(receivedLikes);
+}

--- a/src/app/api/likes/reject/route.ts
+++ b/src/app/api/likes/reject/route.ts
@@ -1,0 +1,59 @@
+/**
+ * @swagger
+ * /api/likes/reject:
+ *   patch:
+ *     summary: 받은 좋아요 거절
+ *     description: |
+ *       로그인한 사용자가 자신에게 온 좋아요 요청을 거절합니다.
+ *       matchId는 /api/likes/received에서 받아온 매칭 ID 사용를 사용합니다.
+ *     tags: [MatchLikes]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - matchId
+ *             properties:
+ *               matchId:
+ *                 type: integer
+ *                 description: 거절할 매칭의 ID
+ *     responses:
+ *       200:
+ *         description: 거절 처리 성공
+ *       403:
+ *         description: 거절 권한 없음
+ */
+
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getAuthUser } from "@/lib/auth";
+
+export async function PATCH(req: Request) {
+  const { matchId } = await req.json();
+  const user = await getAuthUser();
+  if (!user) {
+    return NextResponse.json(
+      { message: "인증되지 않은 사용자입니다." },
+      { status: 401 },
+    );
+  }
+  const userId = user.userId;
+
+  const match = await prisma.userMatchLog.findUnique({ where: { matchId } });
+
+  if (!match || match.receiveId !== userId) {
+    return NextResponse.json(
+      { message: "처리할 수 없는 요청입니다." },
+      { status: 403 },
+    );
+  }
+
+  await prisma.userMatchLog.update({
+    where: { matchId },
+    data: { matchStatus: "REJECTED" },
+  });
+
+  return NextResponse.json({ message: "거절 처리되었습니다." });
+}

--- a/src/app/api/likes/send/route.ts
+++ b/src/app/api/likes/send/route.ts
@@ -1,0 +1,71 @@
+/**
+ * @swagger
+ * /api/likes/send:
+ *   post:
+ *     summary: 특정 유저에게 좋아요 전송
+ *     description: 로그인한 사용자가 다른 사용자에게 좋아요를 보냅니다. 이미 좋아요를 보낸 경우 중복 전송은 불가합니다.
+ *     tags: [MatchLikes]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - receiveId
+ *             properties:
+ *               receiveId:
+ *                 type: integer
+ *                 description: 좋아요를 받을 유저의 ID
+ *     responses:
+ *       201:
+ *         description: 좋아요 전송 성공
+ *       400:
+ *         description: 자기 자신에게는 보낼 수 없음
+ *       409:
+ *         description: 이미 좋아요를 보냄
+ */
+
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getAuthUser } from "@/lib/auth";
+
+export async function POST(req: Request) {
+  const { receiveId } = await req.json();
+  const user = await getAuthUser();
+  if (!user) {
+    return NextResponse.json(
+      { message: "인증되지 않은 사용자입니다." },
+      { status: 401 },
+    );
+  }
+  const sentId = user.userId;
+
+  if (receiveId === sentId) {
+    return NextResponse.json(
+      { message: "자기 자신에게는 보낼 수 없습니다." },
+      { status: 400 },
+    );
+  }
+
+  const existing = await prisma.userMatchLog.findFirst({
+    where: { sentId, receiveId },
+  });
+
+  if (existing) {
+    return NextResponse.json(
+      { message: "이미 좋아요를 보냈습니다." },
+      { status: 409 },
+    );
+  }
+
+  const match = await prisma.userMatchLog.create({
+    data: {
+      sentId,
+      receiveId,
+      matchStatus: "PENDING",
+    },
+  });
+
+  return NextResponse.json(match, { status: 201 });
+}


### PR DESCRIPTION
<!--- PR 제목을 "[카테고리] 구현한 거 설명" 으로 작성했나요? -->
<!--- ex)[feat] 로그인 API 연동 -->

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#57 

## 📝 요약(Summary)
### 특정 유저에게 좋아요 전송 (POST /api/likes/send)
- UserMatchLog 테이블에서 match_status 가 PENDING 으로 생성됩니다.
### 받은 좋아요 수락 (PATCH /api/likes/accept)
- UserMatchLog 테이블에서 match_status 가 ACCEPT 로 변경됩니다.
### 받은 좋아요 거절 (PATCH /api/likes/reject)
- UserMatchLog 테이블에서 match_status 가 REJECTED 로 변경됩니다.
### 받은 좋아요 리스트 조회 (GET /api/likes/received)
- 내가 받은 좋아요 목록을 가져옵니다.
### Swagger 주석 포함
- API에 summary/description/request/response 명세를 추가했습니다.

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
