### PR TITLE
[feat] customFetch 함수 구현

### DIFF
--- a/src/lib/customFetch.ts
+++ b/src/lib/customFetch.ts
@@ -1,0 +1,43 @@
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+
+const ERROR_MESSAGES = {
+  401: "인증이 필요합니다.",
+  403: "접근이 거부되었습니다.",
+  429: "잠시 후 다시 시도해주세요.",
+  default: "처리 중 오류가 발생했습니다.",
+} as const;
+
+export async function customFetch<T = unknown>(
+  input: RequestInfo,
+  init?: RequestInit & { skipJsonParse?: boolean },
+): Promise<T> {
+  const url =
+    typeof input === "string" && !input.startsWith("http")
+      ? `${BASE_URL}${input}`
+      : input;
+
+  const res = await fetch(url, {
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers || {}),
+    },
+    ...init,
+  });
+
+  if (!res.ok) {
+    const statusCode = res.status as keyof typeof ERROR_MESSAGES;
+    const errorMessage = ERROR_MESSAGES[statusCode] || ERROR_MESSAGES.default;
+    throw new Error(errorMessage);
+  }
+
+  if (init?.skipJsonParse) {
+    return res as unknown as T;
+  }
+
+  try {
+    return await res.json();
+  } catch {
+    throw new Error("응답 데이터를 처리할 수 없습니다.");
+  }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

closed #107 

## 📝 요약(Summary)

lib/customFetch.ts에 API 호출 함수를 작성했습니다.
HttpOnly 쿠키에 저장된 JWT 기반 인증 처리, 주요 에러 코드 핸들링, JSON 파싱 등의 역할을 포함합니다.
TanStack Query와 함께 사용할 수 있도록 범용 구조로 작성되었습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?
- [X] 새로운 기능 추가

## 💬 공유사항 to 리뷰어
기본적으로 API호출 로직은 servicese 폴더 하위에 작성하고 tanstack-query 등과 연관된 상태 관리는 hooks 폴더 하위에 커스텀 훅을 생성하여 관리합니다.

### 1. `customFetch` 함수의 역할
+ 브라우저 환경 전용 fetch `wrapper 함수`입니다.
+ 모든 API 요청에 credentials: 'include'가 자동 적용되어 HttpOnly 쿠키를 보냅니다.
+ BASE_URL 자동 prepend (env 설정 필요)
+ status code 에 따른 에러 메시지를 통일적으로 처리합니다.
+ 응답은 기본적으로 .json()으로 파싱되며, 필요 시 skipJsonParse 옵션으로 원본 Response도 받을 수 있습니다.

### 2. 데이터 패칭/캐싱 전략

<html><head></head><body>

상황/기능 | Server Component + fetch | tanstack-query (Client)
-- | -- | --
검색 엔진 노출 필요 (SEO) | ✅ | ❌
정적/비 개인화된 데이터 | ✅ (force-cache) | ❌
개인화된 데이터 | ❌| ✅ (캐싱 + 상태관리)|
무한 스크롤, 낙관적 업데이트 등 | ❌ | ✅ (mutation, optimistic)
로딩/에러 상태 관리 | ❌ | ✅

</body></html>

개인화된 요청은 원격 서버에 캐싱 되어서는 안되기 때문에 fetch를 사용할 때 no-store 옵션을 사용하나, 이 경우 새로고침 및 라우트 캐시가 만료될 때마다 API 호출이 발생하므로 우리는 client-side에서 tanstack query를 사용해 브라우저 메모리에 개인화된 요청에 대한 응답을 캐싱 하고 queryKey와 staleTime으로 캐시를 관리합니다. 개인화 되지 않은 요청은 server-side에서 force-cache 옵션을 사용해 API를 호출하고 적절한 방법을 통해 갱신합니다. 


### 3. 사용 가이드라인

#### 📌  Case 1: 순수 `fetch` (Server Component)

```ts
// 비개인화 데이터 (SEO, 서버 캐싱 활용)
const notices = await fetch('/notices', { 
  cache: 'force-cache'
});
```


#### 📌 Case 2: customFetch + TanStack Query (Client Component)
```ts
const { data } = useQuery({
  queryKey: ['scraps', userId],
  queryFn: () => customFetch('/scraps'),
  staleTime: 1000 * 60 * 5, // 브라우저 메모리에 5분 캐싱
});
```
-> 인증된 사용자 정보 등 개인화된 데이터는 클라이언트에서 요청 후 캐싱합니다.

#### 📌 Case 3: customFetch + useMutation (Client Component)
```ts
const mutation = useMutation({
  mutationFn: (newPost: { title: string; content: string }) =>
    customFetch('/posts', {
      method: 'POST',
      body: JSON.stringify(newPost),
    }),
  onSuccess: () => {
    queryClient.invalidateQueries({ queryKey: ['posts'] });
  },
});
```
-> 서버에 POST/PUT/DELETE 요청을 보낼 때 사용합니다. customFetch로 인증 및 에러 핸들링이 적용되며, mutation의 성공/실패에 따른 상태 관리를 할 수 있습니다.

#### 4. 판단 기준
<html><head></head><body>

질문 | 답변 및 적용 방식
-- | --
인증이 필요한가? | Yes → customFetch 사용
개인화된 데이터인가? | Yes → Client에서 TanStack Query로 캐싱
상호작용이 많은가? | Yes → TanStack Query로 상태 관리
SEO가 필요한가? | Yes → Server Component에서 초기 렌더링(fetch 사용)

</body></html>


제가 알아본 바는 이 정도인데, 논의가 필요한 부분은 리뷰 남겨주십쇼! 어렵네여 ㅎ..ㅎ 🫠