### PR TITLE
[feat] 매칭카드 리스트 및 광고 불러오기 API 구현

### DIFF
--- a/src/app/api/match-cards/route.ts
+++ b/src/app/api/match-cards/route.ts
@@ -1,0 +1,279 @@
+/**
+ * @swagger
+ * /api/match-cards:
+ *   get:
+ *     tags:
+ *       - MatchCards
+ *     summary: 매칭 카드 리스트 조회
+ *     description: |
+ *       15명의 유저 ID를 기준으로 유저 매칭 카드 리스트를 반환합니다.
+ *       각 유저는 기본 정보, 금융상품 카테고리 비율, 부채 비율을 포함하며,
+ *       광고를 위한 subjectType이 '금융상식'이 아닌 랜덤 Subject 1개도 함께 포함됩니다.
+ *     responses:
+ *       200:
+ *         description: 매칭 카드 리스트와 랜덤 subject 반환
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: 매칭 카드 리스트(15)와 광고(1)를 반환했습니다.
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       userId:
+ *                         type: integer
+ *                         example: 122
+ *                       nickname:
+ *                         type: string
+ *                         example: 윤성
+ *                       gender:
+ *                         type: string
+ *                         example: M
+ *                       birthYear:
+ *                         type: integer
+ *                         example: 1994
+ *                       city:
+ *                         type: string
+ *                         example: 서울시 성동구
+ *                       job:
+ *                         type: string
+ *                         example: 프리랜서
+ *                       description:
+ *                         type: string
+ *                         example: 안녕하세요. 윤성입니다.
+ *                       profileImage:
+ *                         type: string
+ *                         format: uri
+ *                         example: https://avatars.githubusercontent.com/u/21414261
+ *                       hasCar:
+ *                         type: boolean
+ *                         example: false
+ *                       hasHouse:
+ *                         type: boolean
+ *                         example: true
+ *                       goalAmount:
+ *                         type: integer
+ *                         example: 571000000
+ *                       goalPeriod:
+ *                         type: string
+ *                         example: WITHIN_5_YEARS
+ *                       goalType:
+ *                         type: string
+ *                         example: LUMPSUM
+ *                       currentType:
+ *                         type: string
+ *                         example: AGGRESSIVE
+ *                       preferredType:
+ *                         type: string
+ *                         example: MODERATE
+ *                       financialProductRatio:
+ *                         type: object
+ *                         properties:
+ *                           financeRatio:
+ *                             type: number
+ *                             example: 1
+ *                           loanRatio:
+ *                             type: number
+ *                             example: 0
+ *                       categoryRatios:
+ *                         type: object
+ *                         properties:
+ *                           SAVINGS:
+ *                             type: number
+ *                             example: 0.3
+ *                           DOMESTIC_STOCKS:
+ *                             type: number
+ *                             example: 0
+ *                           DEVELOPED_STOCKS:
+ *                             type: number
+ *                             example: 0.33
+ *                           EMERGING_STOCKS:
+ *                             type: number
+ *                             example: 0.06
+ *                           DOMESTIC_BONDS:
+ *                             type: number
+ *                             example: 0.21
+ *                           FOREIGN_BONDS:
+ *                             type: number
+ *                             example: 0
+ *                           ALTERNATIVE:
+ *                             type: number
+ *                             example: 0.1
+ *                           CASH:
+ *                             type: number
+ *                             example: 0
+ *                 randomSubject:
+ *                   type: object
+ *                   properties:
+ *                     subjectId:
+ *                       type: integer
+ *                       example: 4
+ *                     subjectType:
+ *                       type: string
+ *                       example: 적금
+ *                     title:
+ *                       type: string
+ *                       example: 부자씨 적금
+ *                     description:
+ *                       type: string
+ *                       example: 하나원큐 로그인 횟수 & 하나 합 서비스 등록에 따라 우대금리 받고, 적금 모아서 예금으로~ 예금이 모여서 목돈을 제공하는 상품
+ *                     features:
+ *                       type: string
+ *                       example: 적금을 모아서 예금으로~
+ *                     period:
+ *                       type: string
+ *                       example: 1년
+ *                     amount:
+ *                       type: string
+ *                       example: 50만원 이하
+ *                     interestRate:
+ *                       type: string
+ *                       example: 최대 연 2.00%(세전)
+ *                     subjectUrl:
+ *                       type: string
+ *                       format: uri
+ *                       example: https://www.kebhana.com/cont/mall/mall08/mall0801/mall080102/1486817_115157.jsp
+ */
+
+type SubjectResponse = {
+  subjectId: number;
+  subjectType: string;
+  title: string;
+  description: string;
+  features: string;
+  period: string;
+  amount: string;
+  interestRate: string;
+  subjectUrl: string | null;
+};
+
+import { prisma } from "@/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(_req: NextRequest) {
+  // 여기에 대현오빠가 만든 함수로 유저 아이디 넘겨주면 됨
+  const userIds = [
+    109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123,
+  ];
+
+  const [randomSubject] = await prisma.$queryRaw<SubjectResponse[]>`
+  SELECT 
+    subject_id as subjectId,
+    subject_type as subjectType,
+    title,
+    description,
+    features,
+    period,
+    amount,
+    interest_rate as interestRate,
+    subject_url as subjectUrl
+  FROM Subject
+  WHERE subject_type != '금융상식'
+  ORDER BY RAND()
+  LIMIT 1
+`;
+
+  try {
+    const [users] = await Promise.all([
+      prisma.user.findMany({
+        where: { userId: { in: userIds }, isDeleted: false },
+        include: {
+          consumeHistory: true,
+          userFinancialProduct: {
+            include: {
+              financialProduct: { select: { category: true } },
+            },
+          },
+          loan: true,
+        },
+      }),
+    ]);
+
+    const data = users.map((user) => {
+      // 금융 상품, 대출 금액 계산
+      const financeTotal = user.userFinancialProduct
+        .filter((p) => p.financialProduct.category !== "LOAN")
+        .reduce((acc, p) => acc + Number(p.currentValue ?? 0), 0);
+
+      const loanTotal = user.loan.reduce(
+        (acc, l) => acc + Number(l.loanBalance ?? 0),
+        0,
+      );
+      const totalValue = financeTotal + loanTotal || 1; // 0 방지
+
+      // financialProductRatio
+      const financialProductRatio = {
+        financeRatio: parseFloat((financeTotal / totalValue).toFixed(2)),
+        loanRatio: parseFloat((loanTotal / totalValue).toFixed(2)),
+      };
+
+      // categoryRatios
+      const categorySums: Record<string, number> = {};
+      for (const p of user.userFinancialProduct) {
+        const category = p.financialProduct.category;
+        if (category === "LOAN") continue;
+        const value = Number(p.currentValue ?? 0);
+        categorySums[category] = (categorySums[category] ?? 0) + value;
+      }
+
+      const entries = Object.entries(categorySums).map(([key, value]) => {
+        const ratio = parseFloat((value / financeTotal).toFixed(2));
+        return { key, ratio };
+      });
+
+      let sum = entries.reduce((acc, { ratio }) => acc + ratio, 0);
+      const diff = parseFloat((1 - sum).toFixed(2));
+      if (entries.length > 0) {
+        entries[entries.length - 1].ratio = parseFloat(
+          (entries[entries.length - 1].ratio + diff).toFixed(2),
+        );
+      }
+
+      const categoryRatios = {
+        SAVINGS: 0,
+        DOMESTIC_STOCKS: 0,
+        DEVELOPED_STOCKS: 0,
+        EMERGING_STOCKS: 0,
+        DOMESTIC_BONDS: 0,
+        FOREIGN_BONDS: 0,
+        ALTERNATIVE: 0,
+        CASH: 0,
+        ...Object.fromEntries(entries.map(({ key, ratio }) => [key, ratio])),
+      };
+
+      return {
+        userId: user.userId,
+        nickname: user.nickname,
+        gender: user.gender,
+        birthYear: user.birthYear,
+        city: user.city,
+        job: user.job,
+        description: user.description,
+        profileImage: user.profileImage,
+        hasCar: user.hasCar,
+        hasHouse: user.hasHouse,
+        goalAmount: Number(user.goalAmount ?? 0),
+        goalPeriod: user.goalPeriod,
+        goalType: user.goalType,
+        currentType: user.currentType,
+        preferredType: user.preferredType,
+        financialProductRatio,
+        categoryRatios,
+      };
+    });
+
+    return NextResponse.json({
+      message: "매칭 카드 리스트와 광고를 반환했습니다.",
+      data,
+      randomSubject,
+    });
+  } catch (err) {
+    console.error("매칭 카드 리스트 오류:", err);
+    return NextResponse.json({ message: "서버 오류" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
<!--- PR 제목을 "[카테고리] 구현한 거 설명" 으로 작성했나요? -->
<!--- ex)[feat] 로그인 API 연동 -->

## #️⃣ Issue Number
#112 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
홈페이지에서 보여줄 매칭카드 리스트와 광고를 가져오는 API를 구현했습니다.
- 매칭 카드 리스트를 위해 15명의 유저 정보를 가져옴
  - 기본 정보, 금융상품별 카테고리 비율, 부채 비율이 포함됨  
- 광고를 위해 Subject 에서 subject_type 이 '금융상식'이 아닌 상품을 랜덤으로 1개 가져옴

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
현재 하드 코딩으로 15명의 유저 아이디를 넣어놨는데 이 부분을 매칭 점수 기반 유저 선정 함수로 변경해야합니다.

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
