### PR TITLE
[feat] 프로필 등록 여부에 따른 로그인 이후 라우팅 분기 처리

### DIFF
--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "next/navigation";
 import { validateEmail } from "@/lib/validators";
 import { useLogin } from "@/hooks/useLogin";
 import { useUserStore } from "@/lib/store/userStore";
+import { checkProfileRegistrationStatus } from "@/services/myProfile";
 
 export default function LoginForm() {
   const [email, setEmail] = useState("");
@@ -26,11 +27,24 @@ export default function LoginForm() {
   };
 
   const loginMutation = useLogin(
-    (data) => {
+    async (data) => {
       if (data.user) {
         setNickname(data.user.nickname);
+
+        try {
+          const profileStatus = await checkProfileRegistrationStatus();
+
+          if (profileStatus.isRegistered) {
+            router.push("/home");
+          } else {
+            router.push("/profile-setup");
+          }
+        } catch {
+          toast.error("프로필 상태 확인에 실패했습니다. 다시 시도해주세요.");
+        }
+      } else {
+        toast.error("로그인 정보를 확인할 수 없습니다. 다시 시도해주세요.");
       }
-      router.push("/home");
       setIsSubmitting(false);
     },
     (error) => {

--- a/src/hooks/useSubmitProfile.ts
+++ b/src/hooks/useSubmitProfile.ts
@@ -3,12 +3,15 @@
 import { useMutation } from "@tanstack/react-query";
 import { submitProfile, ProfilePayload } from "@/services/myProfile";
 import toast from "react-hot-toast";
+import { useRouter } from "next/navigation";
 
 export function useSubmitProfile() {
+  const router = useRouter();
+
   return useMutation({
     mutationFn: (payload: ProfilePayload) => submitProfile(payload),
     onSuccess: () => {
-      toast.success("프로필 등록이 완료되었습니다!");
+      router.push("/pairing-book");
     },
     onError: () => {
       toast.error("프로필 등록 중 오류가 발생했습니다.");

--- a/src/services/myProfile.ts
+++ b/src/services/myProfile.ts
@@ -14,6 +14,22 @@ export interface ProfilePayload {
   houseValue?: string;
 }
 
+export interface ProfileRegistrationStatus {
+  isRegistered: boolean;
+}
+
+export async function checkProfileRegistrationStatus(): Promise<ProfileRegistrationStatus> {
+  try {
+    const response = (await customFetch("/profiles/is-registered", {
+      method: "GET",
+    })) as unknown as ProfileRegistrationStatus;
+
+    return response;
+  } catch {
+    return { isRegistered: false };
+  }
+}
+
 export async function submitProfile(payload: ProfilePayload) {
   const formData = new FormData();
 


### PR DESCRIPTION
## #️⃣ Issue Number

closed #123 

## 📝 요약(Summary)

onboarding 하위 페이지들은 서비스 가입 이후 단 한번만 거치는 페이지 들이기 때문에 로그인 이후 프로필이 등록되어 있는지 여부를 검사하고 등록이 되어 있으면 /home으로, 등록이 되어 있지 않으면 /profile-setup으로 라우팅 되도록 처리했습니다. 미들웨어 설정을 추후 진행할 예정입니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가