### PR TITLE
[fix] 로그인 이후 온보딩 단계별 라우팅 세분화

### DIFF
--- a/src/app/(onboarding)/pairing-book/page.tsx
+++ b/src/app/(onboarding)/pairing-book/page.tsx
@@ -8,6 +8,7 @@ import Input from "@/components/common/input/Input";
 import Button from "@/components/common/button/Button";
 import InfoCard from "@/components/common/InfoCard";
 import AddressSelectGroup from "@/components/common/AddressSelectGroup";
+import { useUserStore } from "@/lib/store/userStore";
 
 const incomeOptions = [
   "400만 원대",
@@ -23,6 +24,7 @@ export default function PairingBookPage() {
   const [selectedCity, setSelectedCity] = useState("");
   const [selectedDistrict, setSelectedDistrict] = useState("");
   const [selectedIncome, setSelectedIncome] = useState<string | null>(null);
+  const nickname = useUserStore((state) => state.nickname);
 
   const isValid = [
     carPrice.trim(),
@@ -47,7 +49,7 @@ export default function PairingBookPage() {
       <InfoCard
         content={
           <>
-            페어링북 문항에 승희님의{" "}
+            페어링북 문항에 {nickname || "회원"}님의{" "}
             <span className="text-hanagreen-normal">경제 가치관</span>을
             담아보세요!
           </>

--- a/src/app/api/profiles/is-registered/route.ts
+++ b/src/app/api/profiles/is-registered/route.ts
@@ -21,9 +21,16 @@
  *             schema:
  *               type: object
  *               properties:
- *                 isRegistered:
+ *                 isProfileCompleted:
  *                   type: boolean
- *                   example: true
+ *                 isPairingCompleted:
+ *                   type: boolean
+ *                 isMyFTTICompleted:
+ *                   type: boolean
+ *                 isPreferredFTTICompleted:
+ *                   type: boolean
+ *                 isAllCompleted:
+ *                   type: boolean
  *       401:
  *         description: 인증되지 않음
  *         content:
@@ -86,22 +93,34 @@ export async function GET(req: NextRequest) {
       }),
     ]);
 
-    const isProfileFilled = !!(
+    const isProfileCompleted = !!(
       currentUser?.profileImage &&
       currentUser?.description &&
       currentUser?.job &&
       currentUser?.goalType &&
       currentUser?.goalAmount &&
-      currentUser?.goalPeriod &&
-      currentUser?.preferredType &&
-      currentUser?.currentType
+      currentUser?.goalPeriod
     );
 
-    const isPairingAnswered = !!pairingAnswer;
+    const isPairingCompleted = !!pairingAnswer;
+    const isMyFTTICompleted = !!currentUser?.currentType;
+    const isPreferredFTTICompleted = !!currentUser?.preferredType;
+    const isAllCompleted =
+      isProfileCompleted &&
+      isPairingCompleted &&
+      isMyFTTICompleted &&
+      isPreferredFTTICompleted;
 
-    const isRegistered = isProfileFilled && isPairingAnswered;
-
-    return NextResponse.json({ isRegistered }, { status: 200 });
+    return NextResponse.json(
+      {
+        isProfileCompleted,
+        isPairingCompleted,
+        isMyFTTICompleted,
+        isPreferredFTTICompleted,
+        isAllCompleted,
+      },
+      { status: 200 },
+    );
   } catch (error) {
     console.error("❌ 등록 여부 확인 실패:", error);
     return NextResponse.json(

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -34,11 +34,31 @@ export default function LoginForm() {
         try {
           const profileStatus = await checkProfileRegistrationStatus();
 
-          if (profileStatus.isRegistered) {
+          if (profileStatus.isAllCompleted) {
             router.push("/home");
-          } else {
-            router.push("/profile-setup");
+            return;
           }
+
+          if (!profileStatus.isProfileCompleted) {
+            router.push("/profile-setup");
+            return;
+          }
+
+          if (!profileStatus.isPairingCompleted) {
+            router.push("/pairing-book");
+            return;
+          }
+
+          if (!profileStatus.isMyFTTICompleted) {
+            router.push("/question");
+            return;
+          }
+
+          if (!profileStatus.isPreferredFTTICompleted) {
+            router.push("/result");
+            return;
+          }
+          router.push("/home");
         } catch {
           toast.error("프로필 상태 확인에 실패했습니다. 다시 시도해주세요.");
         }

--- a/src/services/myProfile.ts
+++ b/src/services/myProfile.ts
@@ -15,7 +15,11 @@ export interface ProfilePayload {
 }
 
 export interface ProfileRegistrationStatus {
-  isRegistered: boolean;
+  isProfileCompleted: boolean;
+  isPairingCompleted: boolean;
+  isMyFTTICompleted: boolean;
+  isPreferredFTTICompleted: boolean;
+  isAllCompleted: boolean;
 }
 
 export async function checkProfileRegistrationStatus(): Promise<ProfileRegistrationStatus> {
@@ -26,7 +30,13 @@ export async function checkProfileRegistrationStatus(): Promise<ProfileRegistrat
 
     return response;
   } catch {
-    return { isRegistered: false };
+    return {
+      isProfileCompleted: false,
+      isPairingCompleted: false,
+      isMyFTTICompleted: false,
+      isPreferredFTTICompleted: false,
+      isAllCompleted: false,
+    };
   }
 }
 


### PR DESCRIPTION
## #️⃣ Issue Number

closed #132 

## 📝 요약(Summary)

**온보딩 단계별 완료 조건**
프로필: profileImage, description, job, goalType, goalAmount, goalPeriod
페어링북: PairingAnswer 레코드 존재
내 FTTI: currentType 값 존재
이상형 FTTI: preferredType 값 존재

해당 조건을 토대로 로그인 이후 미 완료한 단계로 이동하도록 라우팅을 세분화 했습니다. 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 버그 수정
- [X] 코드 리팩토링
