### PR TITLE
[fix] Image Cropper 이미지 자르기 오류 해결

### DIFF
--- a/src/components/profile/imageUploader/ImageCropper.tsx
+++ b/src/components/profile/imageUploader/ImageCropper.tsx
@@ -22,26 +22,47 @@ export default function ImageCropper({
 
   const handleCropComplete = async () => {
     if (!croppedAreaPixels || !onCropComplete) return;
+
     const croppedImage = await getCroppedImg(image, croppedAreaPixels);
     onCropComplete(croppedImage);
   };
 
   return (
     <div className="relative w-full aspect-square">
+      {" "}
       <Cropper
         image={image}
         crop={crop}
         zoom={zoom}
         aspect={1}
-        cropShape="round"
+        cropShape="rect"
         showGrid={false}
+        objectFit="cover" // ⭐ 핵심: 정사각형 crop 영역을 이미지가 꽉 채움 (비율 유지)
         onCropChange={setCrop}
         onZoomChange={setZoom}
         onCropComplete={(_, areaPixels) => {
           setCroppedAreaPixels(areaPixels);
           onCropChange?.(areaPixels);
         }}
+        style={{
+          containerStyle: {
+            width: "100%",
+            height: "100%",
+          },
+        }}
       />
+      <div className="absolute inset-0 pointer-events-none">
+        <div className="w-full h-full flex items-center justify-center">
+          <div
+            className="rounded-full border-2 border-white shadow-lg"
+            style={{
+              width: "min(100%, 320px)",
+              aspectRatio: "1 / 1",
+              boxShadow: "0 0 0 9999px rgba(0, 0, 0, 0.4)",
+            }}
+          />
+        </div>
+      </div>
       {onCropComplete && (
         <button
           onClick={handleCropComplete}

--- a/src/components/profile/imageUploader/ImageUploader.tsx
+++ b/src/components/profile/imageUploader/ImageUploader.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from "react";
 import ImageCropperModal from "@/components/profile/imageUploader/ImageCropperModal";
 import Image from "next/image";
+import { dataURLtoFile } from "@/utils/cropImage";
 
 interface ImageUploaderProps {
   imageUrl?: string;
@@ -34,7 +35,17 @@ export default function ImageUploader({
 
   const handleCropComplete = (croppedDataUrl: string) => {
     setPreview(croppedDataUrl);
-    onChange(file);
+
+    if (file) {
+      const originalName = file.name;
+      const nameWithoutExt =
+        originalName.substring(0, originalName.lastIndexOf(".")) ||
+        originalName;
+      const croppedFileName = `${nameWithoutExt}_cropped.jpg`;
+      const croppedFile = dataURLtoFile(croppedDataUrl, croppedFileName);
+
+      onChange(croppedFile);
+    }
   };
 
   const handleClick = () => {
@@ -55,7 +66,7 @@ export default function ImageUploader({
             className="object-cover rounded-full"
           />
         ) : (
-          <span className="text-3xl text-hanasilver">+</span> //임시
+          <span className="text-3xl text-hanasilver">+</span>
         )}
       </div>
 

--- a/src/utils/cropImage.ts
+++ b/src/utils/cropImage.ts
@@ -7,10 +7,12 @@ export default function getCroppedImg(
   return new Promise((resolve) => {
     const image = new Image();
     image.src = imageSrc;
+
     image.onload = () => {
       const canvas = document.createElement("canvas");
       canvas.width = crop.width;
       canvas.height = crop.height;
+
       const ctx = canvas.getContext("2d");
       if (!ctx) return;
 
@@ -26,7 +28,22 @@ export default function getCroppedImg(
         crop.height,
       );
 
-      resolve(canvas.toDataURL("image/jpeg"));
+      resolve(canvas.toDataURL("image/jpeg", 0.9));
     };
   });
+}
+
+// 데이터 URL을 File 객체로 변환하는 유틸리티 함수
+export function dataURLtoFile(dataUrl: string, filename: string): File {
+  const arr = dataUrl.split(",");
+  const mime = arr[0].match(/:(.*?);/)?.[1] || "image/jpeg";
+  const bstr = atob(arr[1]);
+  let n = bstr.length;
+  const u8arr = new Uint8Array(n);
+
+  while (n--) {
+    u8arr[n] = bstr.charCodeAt(n);
+  }
+
+  return new File([u8arr], filename, { type: mime });
 }


### PR DESCRIPTION
## #️⃣ Issue Number

closed #114 

## 📝 요약(Summary)
### 정방형 이미지 크롭
실제 크롭: 선택한 영역을 정방형으로 실제 크롭하여 저장
비율 유지: objectFit="cover"로 이미지 비율 유지하면서 크롭 영역 꽉 채움
줌 기능: 확대/축소하여 원하는 부분 정확히 선택 가능

### 원형 미리보기
시각적 가이드: 크롭 시 원형 오버레이로 최종 표시될 영역 미리보기
원형 표시: ImageUploader에서 크롭된 이미지를 원형으로 예쁘게 표시

### 실제 파일 업로드
File 객체 변환: 크롭된 이미지를 실제 File 객체로 변환하여 서버 전송
하이브리드 업로드: 이미지 있을 때 FormData, 없을 때 JSON 방식으로 자동 처리

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [X] 버그 수정

## 📸스크린샷 (선택)
<img width="424" alt="스크린샷 2025-06-27 오후 4 21 42" src="https://github.com/user-attachments/assets/49133822-0afa-439d-8c90-25f7737ed390" />
