### PR TITLE
[refactor] 마이페이지 내 카드보기 모달에서 바텀시트로 변경

### DIFF
--- a/src/app/(navbar)/profile/page.tsx
+++ b/src/app/(navbar)/profile/page.tsx
@@ -3,8 +3,6 @@ import DoughnutChart from "@/components/chart/DoughnutChart";
 import MonthlySpendingChart from "@/components/chart/MonthlySpendingChart";
 import Button from "@/components/common/button/Button";
 import DialogButton from "@/components/common/button/DialogButton";
-import { DislikeButton } from "@/components/common/button/ReactionButton";
-import ProfileCardDetail from "@/components/profile/ProfileCardDetail";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import Header from "@/components/common/Header";
@@ -17,6 +15,7 @@ import { customUser } from "@/lib/customUserData";
 import { customConsumeHistory } from "@/lib/customConsumeHistory";
 import { customPairingAnswers } from "@/lib/customParingAnswer";
 import { RightArrow } from "@/assets/assets";
+import CardBottomSheet from "@/components/card/CardBottomSheet";
 
 export default function MyPage() {
   const { data } = useSuspenseQuery(userProfileOptions("me"));
@@ -101,7 +100,7 @@ export default function MyPage() {
   ];
 
   return (
-    <div className="w-full h-full">
+    <div className="w-full h-full scrollbar-hide">
       <div className="flex flex-col gap-5 px-5 py-2">
         <Header title="마이페이지" centerTitle={false} showBackButton={false} />
         {/* 프로필 */}
@@ -125,26 +124,6 @@ export default function MyPage() {
               onClick={() => setShowCard(true)}
               className="text-[0.8rem] font-normal px-8"
             />
-            {/* ProfileCardDetail 모달 */}
-            {showCard && (
-              <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 p-4">
-                <div className="relative bg-white mb-12 rounded-xl shadow-lg max-w-sm w-full max-h-[90vh] overflow-y-auto">
-                  {/* 닫기 버튼 */}
-                  <DislikeButton
-                    size="lg"
-                    onClick={() => setShowCard(false)}
-                    className="absolute top-4 right-4 z-10 "
-                    iconClassName="text-hanablack hover:text-gray-500 active:text-gray-900"
-                  />
-                  <ProfileCardDetail
-                    user={user}
-                    answers={answer}
-                    data={consumeHistoryData}
-                    modalView={true}
-                  />
-                </div>
-              </div>
-            )}
           </div>
         </div>
 
@@ -208,6 +187,16 @@ export default function MyPage() {
           return null;
         })}
       </div>
+      {/* ProfileCardDetail 모달 */}
+      {
+        <CardBottomSheet
+          user={user}
+          answers={answer}
+          data={consumeHistoryData}
+          open={showCard}
+          onClose={() => setShowCard(false)}
+        />
+      }
     </div>
   );
 }

--- a/src/components/card/CardBottomSheet.tsx
+++ b/src/components/card/CardBottomSheet.tsx
@@ -1,0 +1,43 @@
+import ProfileCardDetail from "../profile/ProfileCardDetail";
+import { ProfileCardProps } from "../profile/types/profileCardTypes";
+import { ConsumeHistory } from "@/app/types/profiles";
+import BottomSheet from "../common/BottomSheet";
+
+type Props = {
+  open: boolean;
+  user: ProfileCardProps;
+  answers: { id: number; answer: string }[];
+  data: ConsumeHistory;
+  onClose: () => void;
+};
+
+export default function CardBottomSheet({
+  open,
+  user,
+  answers,
+  data,
+  onClose,
+}: Props) {
+  return (
+    <BottomSheet open={open} onClose={onClose}>
+      {/* 바텀시트 라벨 */}
+      <h2 className="my-4 text-xl text-text-primary text-center font-semibold">
+        내 카드보기
+      </h2>
+      {/* 바텀시트 내용 */}
+      <div
+        className="flex-1 overflow-y-auto px-5 py-2 bg-white mb-20 scrollbar-hide"
+        style={{
+          WebkitOverflowScrolling: "touch",
+        }}
+      >
+        <ProfileCardDetail
+          user={user}
+          answers={answers}
+          data={data}
+          modalView={true}
+        />
+      </div>
+    </BottomSheet>
+  );
+}

--- a/src/components/chat/portfolio/ChatPortfolioBottomSheet.tsx
+++ b/src/components/chat/portfolio/ChatPortfolioBottomSheet.tsx
@@ -1,5 +1,3 @@
-import Button from "@/components/common/button/Button";
-import { cn } from "@/utils/cn";
 import ChatPortfolio from "./ChatPortfolio";
 import {
   categoryKeys,
@@ -7,6 +5,7 @@ import {
   PortfolioCategoryColorMap,
   PortfolioCategoryLabelMap,
 } from "@/app/types/profile";
+import BottomSheet from "@/components/common/BottomSheet";
 
 type Props = {
   open: boolean;
@@ -23,94 +22,63 @@ export default function ChatPortfolioBottomSheet({
   partnerPortfolioData,
   onClose,
 }: Props) {
-  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (e.target === e.currentTarget) {
-      onClose();
-    }
-  };
-
   return (
-    <div>
-      {open && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
-          onClick={handleBackdropClick}
-        />
-      )}
-      <div
-        className={cn(
-          "fixed frame-container left-0 right-0 bottom-0 z-50 transition-transform duration-300",
-          open ? "translate-y-0-cross" : "translate-y-full-cross",
-        )}
-        style={{ maxHeight: "90vh" }}
-      >
-        <div className="relative flex flex-col w-full h-full px-5 rounded-t-3xl bg-white">
-          {/* 바텀시트 라벨 */}
-          <h2 className="my-5 text-xl text-text-primary text-center font-semibold">
-            포트폴리오 비교하기
-          </h2>
-          {/* 바텀시트 내용 */}
-          <div className="flex-grow overflow-y-auto bg-white mb-24">
-            {/* 포트폴리오 차트 */}
-            <div className="flex mb-8 justify-evenly">
-              <div className="flex flex-col items-center gap-2">
-                <p className="text-text-primary text-base font-semibold">나</p>
-                <ChatPortfolio values={myPortfolioData} />
-              </div>
-              <div className="flex flex-col items-center gap-2">
-                <p className="text-text-primary text-base font-semibold">
-                  {partnerNickname ?? "상대방"}
-                </p>
-                <ChatPortfolio values={partnerPortfolioData} />
-              </div>
+    <BottomSheet open={open} onClose={onClose}>
+      <div className="w-full px-5">
+        {/* 바텀시트 라벨 */}
+        <h2 className="my-5 text-xl text-text-primary text-center font-semibold">
+          포트폴리오 비교하기
+        </h2>
+        {/* 바텀시트 내용 */}
+        <div className="flex-grow overflow-y-auto bg-white mb-24">
+          {/* 포트폴리오 차트 */}
+          <div className="flex mb-8 justify-evenly">
+            <div className="flex flex-col items-center gap-2">
+              <p className="text-text-primary text-base font-semibold">나</p>
+              <ChatPortfolio values={myPortfolioData} />
             </div>
-            {/* 포트폴리오 내용 */}
-            <div className="px-5">
-              <div className="pb-1 mb-2 flex items-center border-b border-b-hanagreen-light font-semibold text-text-primary">
-                <div className="w-44">자산유형</div>
-                <p className="flex-1 text-end">나</p>
-                <p className="flex-1 text-end">상대방</p>
-              </div>
-              {myPortfolioData &&
-                partnerPortfolioData &&
-                categoryKeys.map((category, idx) => {
-                  const typedCategory = category as keyof CategoryRatios;
-                  return (
-                    <div key={idx} className="flex text-text-primary">
-                      <div className="flex w-44 justify-start items-center gap-2">
-                        <span
-                          className="w-2 h-2 rounded-full"
-                          style={{
-                            backgroundColor:
-                              PortfolioCategoryColorMap[typedCategory],
-                          }}
-                        />
-                        <span>{PortfolioCategoryLabelMap[typedCategory]}</span>
-                      </div>
-                      <p className="flex-1 text-end">
-                        {myPortfolioData[typedCategory] ?? 0}%
-                      </p>
-                      <p className="flex-1 text-end">
-                        {partnerPortfolioData[typedCategory] ?? 0}%
-                      </p>
-                    </div>
-                  );
-                })}
+            <div className="flex flex-col items-center gap-2">
+              <p className="text-text-primary text-base font-semibold">
+                {partnerNickname ?? "상대방"}
+              </p>
+              <ChatPortfolio values={partnerPortfolioData} />
             </div>
           </div>
-          {/* 바텀시트 하단버튼 */}
-          <div className="absolute bottom-0 left-0 py-4 px-5 w-full bg-white">
-            <Button
-              className="w-full rounded-lg"
-              intent="green"
-              size="full"
-              onClick={onClose}
-            >
-              확인
-            </Button>
+          {/* 포트폴리오 내용 */}
+          <div className="px-5">
+            <div className="pb-1 mb-2 flex items-center border-b border-b-hanagreen-light font-semibold text-text-primary">
+              <div className="w-44">자산유형</div>
+              <p className="flex-1 text-end">나</p>
+              <p className="flex-1 text-end">상대방</p>
+            </div>
+            {myPortfolioData &&
+              partnerPortfolioData &&
+              categoryKeys.map((category, idx) => {
+                const typedCategory = category as keyof CategoryRatios;
+                return (
+                  <div key={idx} className="flex text-text-primary">
+                    <div className="flex w-44 justify-start items-center gap-2">
+                      <span
+                        className="w-2 h-2 rounded-full"
+                        style={{
+                          backgroundColor:
+                            PortfolioCategoryColorMap[typedCategory],
+                        }}
+                      />
+                      <span>{PortfolioCategoryLabelMap[typedCategory]}</span>
+                    </div>
+                    <p className="flex-1 text-end">
+                      {myPortfolioData[typedCategory] ?? 0}%
+                    </p>
+                    <p className="flex-1 text-end">
+                      {partnerPortfolioData[typedCategory] ?? 0}%
+                    </p>
+                  </div>
+                );
+              })}
           </div>
         </div>
       </div>
-    </div>
+    </BottomSheet>
   );
 }

--- a/src/components/common/BottomSheet.tsx
+++ b/src/components/common/BottomSheet.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { cn } from "@/utils/cn";
+import { PropsWithChildren, useEffect } from "react";
+import Button from "./button/Button";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export default function BottomSheet({
+  open,
+  onClose,
+  children,
+}: PropsWithChildren<Props>) {
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div>
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
+          onClick={handleBackdropClick}
+        />
+      )}
+      <div
+        className={cn(
+          "fixed frame-container h-full bottom-0 left-0 right-0 z-50 transition-transform duration-300",
+          open ? "translate-y-0" : "translate-y-full",
+        )}
+        style={{ maxHeight: "90vh", zIndex: 60 }}
+      >
+        <div className="relative flex flex-col items-center w-full h-full rounded-t-3xl bg-white">
+          {children}
+          {/* 바텀시트 하단버튼 */}
+          <div className="absolute bottom-0 left-0 py-4 px-5 w-full bg-white">
+            <Button
+              className="w-full rounded-lg"
+              intent="green"
+              size="full"
+              onClick={onClose}
+            >
+              확인
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
<!--- PR 제목을 "[카테고리] 구현한 거 설명" 으로 작성했나요? -->
<!--- ex)[feat] 로그인 API 연동 -->

## #️⃣ Issue Number
#203 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
마이페이지 내 카드보기를 모달에서 바텀시트로 변경했습니다.
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] CSS 등 사용자 UI 디자인 변경

## 📸스크린샷 (선택)
화면 명 | 설명 | 이미지
--- | --- | ---
마이페이지 | 내 카드보기 | <img width=350 src=https://github.com/user-attachments/assets/d91fc8d1-a00b-4529-89d9-54bf16885662>

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
